### PR TITLE
[CU-86b8rd19x] Add PR validation pipeline and fix logback CVE

### DIFF
--- a/.github/workflows/build-test-analyse.yml
+++ b/.github/workflows/build-test-analyse.yml
@@ -1,0 +1,41 @@
+name: Build, Test & Analyse
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test-java-app:
+    name: Build & Test Java App
+    uses: DNAstack/dnastack-development-tools/.github/workflows/build-test-java-app.yml@d01a9e8068e2bc4b92536ea6d8f536b48dcd1699
+    with:
+      java-version: 11
+    secrets:
+      pat-with-read-packages-permission: ${{ secrets.AUTH_TOKEN }}
+
+  sast:
+    name: SAST (SonarQube)
+    uses: DNAstack/dnastack-development-tools/.github/workflows/sast.yml@d01a9e8068e2bc4b92536ea6d8f536b48dcd1699
+    with:
+      with-frontend: false
+      java-version: 11
+    secrets:
+      pat-with-read-packages-permission: ${{ secrets.AUTH_TOKEN }}
+      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+
+  sca:
+    name: SCA (Trivy)
+    uses: DNAstack/dnastack-development-tools/.github/workflows/sca.yml@d01a9e8068e2bc4b92536ea6d8f536b48dcd1699
+    with:
+      java-version: 11
+    secrets:
+      pat-with-read-packages-permission: ${{ secrets.AUTH_TOKEN }}
+
+  secrets-detection:
+    name: Secrets Detection (Gitleaks)
+    uses: DNAstack/dnastack-development-tools/.github/workflows/secrets-detection.yml@d01a9e8068e2bc4b92536ea6d8f536b48dcd1699
+    secrets:
+      gitleaks-license: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Gitleaks configuration — controls secret scanning behavior.
+# See: https://github.com/gitleaks/gitleaks#configuration
+
+# Use the default detection rules.
+[extend]
+  useDefault = true
+
+# Exclude build artifacts and dependency directories from scanning.
+[[allowlists]]
+  description = "exclude build artifacts and dependency directories"
+  paths = [
+    '''target/''',
+  ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# Gitleaks ignore file — suppresses known/accepted secret findings.
+# Each line is a fingerprint from gitleaks output. New secrets in the same
+# files will still be caught — only these specific findings are suppressed.
+#
+# To add a new entry: run `gitleaks detect --source . --no-git -v`,
+# copy the Fingerprint line, and add it here with a comment explaining why.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,8 @@
+# Trivy ignore file for known/accepted vulnerabilities.
+# See: https://trivy.dev/docs/configuration/filtering/#trivyignoreyaml
+#
+# Format:
+#   vulnerabilities:
+#     - id: CVE-XXXX-XXXXX
+#       reason: "Why this is acceptable"
+#       expired_at: 2026-XX-XXT00:00:00Z

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.13</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
- Add Build & Test, SAST (SonarQube), SCA (Trivy), Secrets Detection (Gitleaks) workflows
- Bump logback-classic 1.2.8 → 1.2.13 (fixes CVE-2023-6378 serialization vulnerability)
- Add .gitleaks.toml, .gitleaksignore, .trivyignore.yaml

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
